### PR TITLE
Starting disk size revised.  Added script to (optionally) 'shrink/sparsify'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,8 @@
 Simple script to create kvm and automate the install of Rocky 9 with a kickstart file.
 Script will back up the current template appending the date to the name and spin up a new template.
 
-
-
 ## How It's Made:
-**Tech used:** bash, kvm, kickstart
+**Tech used:** bash, kvm, kickstart, virt-sparsify
 
 ## Example:
 
@@ -14,5 +12,21 @@ Get up and running:
 ./mkvirt.sh test
 ```
 
-You can run it without the vm name and the script will build the default template. 
-This is helpful if you need to test a one off solution or develop a feature without impacting the production template.
+Optionally, the QCOW2 file generated as a result of above can be "shrunk/sparsified" once the
+kickstart processing is completed by running the following:
+```
+sudo ./shrinkit.sh test
+```
+
+Both shell scripts ("mkvirt" and "shrinkit"), will default to use "rocky9-template" as the KVM
+when a parameter is NOT passed upon execution.  This is helpful if you need to test a one-off
+solution or develop a feature without impacting the production template.
+
+Average total duration for executing both SCRIPTS in sequence during unit testing: 37m45s
+  Comprised of roughly 5m for "mkvirt.sh" and 32m45s for "shrinkit.sh".
+
+Restrictions:
+- Not intended to have multiple simulataneous executions for either script on a single host.
+- As noted with "sudo" above, the "shrinkit.sh" script MUST be run as "root" user.  "mkvirt.sh"
+  script, however, can be run by non-root as long as the QEMU user has access to the designated
+  folder(s). 

--- a/mkvirt.sh
+++ b/mkvirt.sh
@@ -21,7 +21,7 @@ function create_virt() {
   --os-variant rocky9 \
   --accelerate \
   --network bridge=br0,model=virtio \
-  --disk path=/srv/vmdisks/"${vm_name}".qcow2,size=80 \
+  --disk path=/srv/vmdisks/"${vm_name}".qcow2,size=140 \
   --initrd-inject=rocky9.cfg \
   --extra-args='inst.ks=file:rocky9.cfg fips=1 console=tty0 console=ttyS0,9600' \
   --location /srv/iso/Rocky-9.4-x86_64-dvd.iso \

--- a/rocky9.cfg
+++ b/rocky9.cfg
@@ -84,7 +84,7 @@ logvol /              --fstype=xfs  --name=root          --vgname=rl --size=1024
 logvol /home          --fstype=xfs  --name=home          --vgname=rl --size=10240   --fsoptions="nodev,nosuid,noexec"
 logvol /tmp           --fstype=xfs  --name=tmp           --vgname=rl --size=10240   --fsoptions="nodev,nosuid,noexec"
 logvol /var/tmp       --fstype=xfs  --name=var_tmp       --vgname=rl --size=10240   --fsoptions="nodev,nosuid,noexec"
-logvol /var           --fstype=xfs  --name=var           --vgname=rl --size=10240   --fsoptions="nodev"
+logvol /var           --fstype=xfs  --name=var           --vgname=rl --size=76800   --fsoptions="nodev"
 logvol /var/log       --fstype=xfs  --name=var_log       --vgname=rl --size=10240   --fsoptions="nodev,nosuid,noexec"
 logvol /var/log/audit --fstype=xfs  --name=var_log_audit --vgname=rl --size=10240   --fsoptions="nodev,nosuid,noexec"
 logvol swap           --fstype=swap --name=swap          --vgname=rl --size=2048 

--- a/shrinkit.sh
+++ b/shrinkit.sh
@@ -1,0 +1,56 @@
+#!/bin/bash +x
+#
+# Script is used "shrink" the generated qcow2 image file.
+# The script is INTENDED to be run after ./mkvirt.sh and will
+#  check to ensure that the named KVM is "shut off" in "virsh list"
+#  output.  If the KVM is instead "running", this script will
+#  re-check every 3 seconds UNTIL either:
+#   - the KVM State changes to "shut off" -or-
+#   - the duration (in seconds) exceeds the TIMEOUT value
+
+date
+
+timeout=360
+end=$((SECONDS+timeout))
+base_dir="/srv/vmdisks"
+retval=1
+
+if [ "$EUID" -ne 0 ]; then
+	echo "Please run as root"
+	exit
+fi
+
+if [[ -n ${1} ]]; then
+	vm_name=${1}
+else
+	vm_name="rocky9-template"
+fi
+
+echo "KVM name: ${vm_name}"
+echo "Max time allowed: ${end}s"
+
+while [ $SECONDS -lt $end ]; do
+	kvm_state=`virsh list --all | grep "${vm_name}" | tr -s " " | cut -d " " -f 4-`
+	echo ${vm_name} ... ${kvm_state} ... ${SECONDS}s/${end}s
+	if [[ ${kvm_state} = 'shut off' ]]; then
+		retval=0
+		break
+	fi
+	sleep 3
+done
+
+#echo "retval = ${retval}"
+if [ $retval -eq 0 ]; then
+	echo "Switching to '${base_dir}'..."
+	cd ${base_dir}
+	echo "Launching virt-sparsify to process ${vm_name}.qcow2..."
+	virt-sparsify --check-tmpdir warn ${vm_name}.qcow2 sparsified.qcow2
+	ls -l ${vm_name}.qcow2 sparsified.qcow2
+	rm ${vm_name}.qcow2
+	mv sparsified.qcow2 ${vm_name}.qcow2
+else
+	echo "Surpassed timeout and KVM not 'shut off'. Bypassing 'virt-sparsify'"
+fi
+
+date
+exit ${retval}


### PR DESCRIPTION
'shrink/sparsify' of the baseOS template file does take significant time - but saves time when that file is "copied" during provisioning of one or more KVMs.